### PR TITLE
Add unix implementation when compiling for WASM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ bencher = "0.1.5"
 once_cell_cache = []
 lazy_static_cache = ["lazy_static"]
 unsafe_cache = []
+use_unix_paths_on_wasm = []
 
 [[bench]]
 name = "bench"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,7 +243,7 @@ mod parse_dot;
 #[macro_use]
 mod macros;
 
-#[cfg(unix)]
+#[cfg(any(unix, all(target_family = "wasm", feature = "use_unix_paths_on_wasm")))]
 mod unix;
 
 #[cfg(windows)]


### PR DESCRIPTION
Hey, I am using `path-absolutize` in a crate and want to compile it to wasm. It currently doesn't compile as in this crate `ParseDot` is only implemented on `Path` when in `unix` and `windows` environments. 

So I have added when compiling for wasm this crate uses the unix `ParseDot` implementation (as unix paths are more *weby*). It is only under the feature `use_unix_paths_on_wasm` to prevent accidently confusion. 

If and when this is merged I will add a similar implementation for https://github.com/magiclen/path-absolutize

Thanks